### PR TITLE
ROSパッケージ化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(rtcop)
+
+find_package(catkin REQUIRED)
+
+catkin_package(
+  INCLUDE_DIRS Include
+  LIBRARIES libRTCOP.a
+)
+
+#############
+## Install ##
+#############
+
+install(FILES Library/Linux/x64/libRTCOP.a
+   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+install(FILES Tool/LayerCompiler.exe Tool/Sprache.dll
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY Include/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".git" EXCLUDE
+)
+

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>rtcop</name>
+  <version>1.0.0</version>
+  <description>The rtcop package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="hisazumi@gmail.com">Kenji Hisazumi</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/rtcop</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/readme.txt
+++ b/readme.txt
@@ -11,3 +11,11 @@
 ・Test:		テストプログラムと、テストするための場所の提供
 			ビルド時のアセンブリは、ここに出力される
 			テストを終えたら、開発者がLibraryやToolにアセンブリを移す
+
+# ROS package
+
+1. Clone this project into your catkin workspace
+2. catkin build
+
+Refer following URL how to use RTCOP from your ROS project
+https://github.com/hisazumi/crostest


### PR DESCRIPTION
ROSパッケージ化のためのファイルを追加しています。
catkin workspaceにcloneしてbuildするだけで、他のパッケージからRTCOPの機能を使えます。
アプリケーションの書き方例はこちら:
https://github.com/hisazumi/crostest

RTCOPにマージしても良いと判断した場合はマージをお願いします。
別に管理するべきであれば、その旨、お知らせください。